### PR TITLE
Use plain int for response.status_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Let's get started...
 ```python
 >>> import http3
 >>> r = http3.get('https://www.example.org/')
+>>> r
+<Response [200 OK]>
 >>> r.status_code
-<StatusCode.OK: 200>
+200
 >>> r.protocol
 'HTTP/2'
 >>> r.headers['content-type']

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,7 +37,7 @@
 *An HTTP response.*
 
 * `def __init__(...)`
-* `.status_code` - **int** *(Typically a `StatusCode` IntEnum.)*
+* `.status_code` - **int**
 * `.reason_phrase` - **str**
 * `.protocol` - `"HTTP/2"` or `"HTTP/1.1"`
 * `.url` - **URL**

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,10 @@ Let's get started...
 ```python
 >>> import http3
 >>> r = http3.get('https://www.example.org/')
+>>> r
+<Response [200 OK]>
 >>> r.status_code
-<StatusCode.OK: 200>
+200
 >>> r.protocol
 'HTTP/2'
 >>> r.headers['content-type']

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,6 +15,8 @@ Now, let’s try to get a webpage.
 
 ```python
 >>> r = http3.get('https://httpbin.org/get')
+>>> r
+<Response [200 OK]>
 ```
 
 Similarly, to make an HTTP POST request:
@@ -233,21 +235,13 @@ We can inspect the HTTP status code of the response:
 ```python
 >>> r = http3.get('https://httpbin.org/get')
 >>> r.status_code
-<StatusCode.OK: 200>
-```
-
-The status code is an integer enum, meaning that the Python representation gives
-use some descriptive information, but the value itself can be used as a regular integer.
-
-```python
->>> r.status_code == 200
-True
+200
 ```
 
 HTTP3 also includes an easy shortcut for accessing status codes by their text phrase.
 
 ```python
->>> r.status_code == requests.codes.OK
+>>> r.status_code == http3.codes.OK
 True
 ```
 
@@ -256,7 +250,7 @@ We can raise an exception for any Client or Server error responses (4xx or 5xx s
 ```python
 >>> not_found = http3.get('https://httpbin.org/status/404')
 >>> not_found.status_code
-<StatusCode.NOT_FOUND: 404>
+404
 >>> not_found.raise_for_status()
 Traceback (most recent call last):
   File "/Users/tomchristie/GitHub/encode/httpcore/http3/models.py", line 776, in raise_for_status
@@ -348,9 +342,9 @@ For example, GitHub redirects all HTTP requests to HTTPS.
 >>> r.url
 URL('https://github.com/')
 >>> r.status_code
-<StatusCode.OK: 200>
+200
 >>> r.history
-[<Response [301]>]
+[<Response [301 Moved Permanently]>]
 ```
 
 You can modify the default redirection handling with the allow_redirects parameter:
@@ -370,7 +364,7 @@ If you’re making a `HEAD` request, you can use this to enable redirection:
 >>> r.url
 'https://github.com/'
 >>> r.history
-[<Response [301]>]
+[<Response [301 Moved Permanently]>]
 ```
 
 ## Timeouts

--- a/http3/client.py
+++ b/http3/client.py
@@ -609,7 +609,6 @@ class Client(BaseClient):
 
         response = Response(
             status_code=async_response.status_code,
-            reason_phrase=async_response.reason_phrase,
             protocol=async_response.protocol,
             headers=async_response.headers,
             content=sync_content,

--- a/http3/dispatch/http11.py
+++ b/http3/dispatch/http11.py
@@ -67,14 +67,12 @@ class HTTP11Connection:
             event = await self._receive_event(timeout)
 
         assert isinstance(event, h11.Response)
-        reason_phrase = event.reason.decode("ascii", errors="ignore")
         status_code = event.status_code
         headers = event.headers
         content = self._body_iter(timeout)
 
         return AsyncResponse(
             status_code=status_code,
-            reason_phrase=reason_phrase,
             protocol="HTTP/1.1",
             headers=headers,
             content=content,

--- a/http3/dispatch/threaded.py
+++ b/http3/dispatch/threaded.py
@@ -64,7 +64,6 @@ class ThreadedDispatcher(AsyncDispatcher):
 
         return AsyncResponse(
             status_code=sync_response.status_code,
-            reason_phrase=sync_response.reason_phrase,
             protocol=sync_response.protocol,
             headers=sync_response.headers,
             content=async_content,

--- a/http3/models.py
+++ b/http3/models.py
@@ -658,20 +658,22 @@ class BaseResponse:
         self,
         status_code: int,
         *,
-        reason_phrase: str = None,
         protocol: str = None,
         headers: HeaderTypes = None,
         request: BaseRequest = None,
         on_close: typing.Callable = None,
     ):
-        self.status_code = StatusCode.enum_or_int(status_code)
-        self.reason_phrase = StatusCode.get_reason_phrase(status_code)
+        self.status_code = status_code
         self.protocol = protocol
         self.headers = Headers(headers)
 
         self.request = request
         self.on_close = on_close
         self.next = None  # typing.Optional[typing.Callable]
+
+    @property
+    def reason_phrase(self) -> str:
+        return StatusCode.get_reason_phrase(self.status_code)
 
     @property
     def url(self) -> typing.Optional[URL]:
@@ -807,7 +809,7 @@ class BaseResponse:
         return self._cookies
 
     def __repr__(self) -> str:
-        return f"<Response({self.status_code}, {self.reason_phrase!r})>"
+        return f"<Response [{self.status_code} {self.reason_phrase}])>"
 
 
 class AsyncResponse(BaseResponse):
@@ -815,7 +817,6 @@ class AsyncResponse(BaseResponse):
         self,
         status_code: int,
         *,
-        reason_phrase: str = None,
         protocol: str = None,
         headers: HeaderTypes = None,
         content: AsyncResponseContent = None,
@@ -825,7 +826,6 @@ class AsyncResponse(BaseResponse):
     ):
         super().__init__(
             status_code=status_code,
-            reason_phrase=reason_phrase,
             protocol=protocol,
             headers=headers,
             request=request,
@@ -896,7 +896,6 @@ class Response(BaseResponse):
         self,
         status_code: int,
         *,
-        reason_phrase: str = None,
         protocol: str = None,
         headers: HeaderTypes = None,
         content: ResponseContent = None,
@@ -906,7 +905,6 @@ class Response(BaseResponse):
     ):
         super().__init__(
             status_code=status_code,
-            reason_phrase=reason_phrase,
             protocol=protocol,
             headers=headers,
             request=request,

--- a/http3/status_codes.py
+++ b/http3/status_codes.py
@@ -26,13 +26,6 @@ class StatusCode(IntEnum):
         return str(self.value)
 
     @classmethod
-    def enum_or_int(cls, value: int) -> int:
-        try:
-            return StatusCode(value)
-        except ValueError:
-            return value
-
-    @classmethod
     def get_reason_phrase(cls, value: int) -> str:
         try:
             return StatusCode(value).phrase  # type: ignore

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -12,7 +12,7 @@ async def test_get(server):
     assert response.text == "Hello, world!"
     assert response.protocol == "HTTP/1.1"
     assert response.headers
-    assert repr(response) == "<Response(200, 'OK')>"
+    assert repr(response) == "<Response [200 OK])>"
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -37,7 +37,7 @@ def test_get(server):
     assert response.request.url == http3.URL(url)
     assert response.headers
     assert response.is_redirect is False
-    assert repr(response) == "<Response(200, 'OK')>"
+    assert repr(response) == "<Response [200 OK])>"
 
 
 @threadpool

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -22,7 +22,7 @@ def test_response():
 
 def test_response_repr():
     response = http3.Response(200, content=b"Hello, world!")
-    assert repr(response) == "<Response(200, 'OK')>"
+    assert repr(response) == "<Response [200 OK])>"
 
 
 def test_response_content_type_encoding():


### PR DESCRIPTION
Use a plain int for `response.status_code`.

This is more consistent than sometimes using a `StatusCodes` IntEnum for known status codes, and ints for unknown status codes. We keep the nice status code usability by ensuring that the response repr itself includes the reason phrase.