### PR TITLE
Add `base_url` support.

### DIFF
--- a/http3/__init__.py
+++ b/http3/__init__.py
@@ -49,4 +49,4 @@ from .models import (
 )
 from .status_codes import StatusCode, codes
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/http3/models.py
+++ b/http3/models.py
@@ -183,14 +183,18 @@ class URL:
     def copy_with(self, **kwargs: typing.Any) -> "URL":
         return URL(self.components.copy_with(**kwargs))
 
-    def resolve_with(self, base_url: URLTypes) -> "URL":
+    def join(self, relative_url: URLTypes) -> "URL":
         """
-        Return an absolute URL, using base_url as the base.
+        Return an absolute URL, using given this URL as the base.
         """
+        if self.is_relative_url:
+            return URL(relative_url)
+
         # We drop any fragment portion, because RFC 3986 strictly
         # treats URLs with a fragment portion as not being absolute URLs.
-        base_url = URL(base_url).copy_with(fragment=None)
-        return URL(self.components.resolve_with(base_url.components))
+        base_components = self.components.copy_with(fragment=None)
+        relative_url = URL(relative_url, allow_relative=True)
+        return URL(relative_url.components.resolve_with(base_components))
 
     def __hash__(self) -> int:
         return hash(str(self))

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -141,3 +141,12 @@ def test_delete(server):
         response = http.delete("http://127.0.0.1:8000/")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
+
+
+@threadpool
+def test_base_url(server):
+    base_url = "http://127.0.0.1:8000/"
+    with http3.Client(base_url=base_url) as http:
+        response = http.get('/')
+    assert response.status_code == 200
+    assert str(response.url) == base_url


### PR DESCRIPTION
Allows the usage of eg. `client = Client(base_url="https://www.example.com")`

This is particularly useful when used as a test client, so eg.

```python
client = Client(app=app, base_url="https://testserver")
r = client.get('/')
```

If the test client is setup in fixtures, then test cases can just use relative URLs everywhere for testing the application.