### PR TITLE
Handle early connection closes

### DIFF
--- a/http3/client.py
+++ b/http3/client.py
@@ -81,7 +81,7 @@ class BaseClient:
             async_dispatch = dispatch
 
         if base_url is None:
-            self.base_url = URL('', allow_relative=True)
+            self.base_url = URL("", allow_relative=True)
         else:
             self.base_url = URL(base_url)
 

--- a/http3/concurrency.py
+++ b/http3/concurrency.py
@@ -12,10 +12,12 @@ import asyncio
 import functools
 import ssl
 import typing
+from types import TracebackType
 
 from .config import DEFAULT_TIMEOUT_CONFIG, PoolLimits, TimeoutConfig
 from .exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
 from .interfaces import (
+    BaseBackgroundManager,
     BasePoolSemaphore,
     BaseReader,
     BaseWriter,
@@ -193,3 +195,29 @@ class AsyncioBackend(ConcurrencyBackend):
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         return PoolSemaphore(limits)
+
+    def background_manager(
+        self, coroutine: typing.Callable, args: typing.Any
+    ) -> "BackgroundManager":
+        return BackgroundManager(coroutine, args)
+
+
+class BackgroundManager(BaseBackgroundManager):
+    def __init__(self, coroutine: typing.Callable, args: typing.Any) -> None:
+        self.coroutine = coroutine
+        self.args = args
+
+    async def __aenter__(self) -> "BackgroundManager":
+        loop = asyncio.get_event_loop()
+        self.task = loop.create_task(self.coroutine(*self.args))
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        await self.task
+        if exc_type is None:
+            self.task.result()

--- a/http3/concurrency.py
+++ b/http3/concurrency.py
@@ -41,7 +41,7 @@ def ssl_monkey_patch() -> None:
     _write = MonkeyPatch.write
 
     def _fixed_write(self, data: bytes) -> None:  # type: ignore
-        if not self._loop.is_closed():
+        if self._loop and not self._loop.is_closed():
             _write(self, data)
 
     MonkeyPatch.write = _fixed_write

--- a/http3/dispatch/connection.py
+++ b/http3/dispatch/connection.py
@@ -82,10 +82,12 @@ class HTTPConnection(AsyncDispatcher):
             host, port, ssl_context, timeout
         )
         if protocol == Protocol.HTTP_2:
-            self.h2_connection = HTTP2Connection(reader, writer, on_release=on_release)
+            self.h2_connection = HTTP2Connection(
+                reader, writer, self.backend, on_release=on_release
+            )
         else:
             self.h11_connection = HTTP11Connection(
-                reader, writer, on_release=on_release
+                reader, writer, self.backend, on_release=on_release
             )
 
     async def close(self) -> None:

--- a/http3/dispatch/http11.py
+++ b/http3/dispatch/http11.py
@@ -100,8 +100,9 @@ class HTTP11Connection:
             event = h11.EndOfMessage()
             await self._send_event(event, timeout)
         except OSError:  # pragma: nocover
-            # We don't actually care about connection errors when sending the
-            # request body. Defer to exceptions in the response, if any.
+            # Once we've sent the initial part of the request we don't actually
+            # care about connection errors that occur when sending the body.
+            # Ignore these, and defer to any exceptions on reading the response.
             pass
 
     async def _send_event(self, event: H11Event, timeout: TimeoutConfig = None) -> None:

--- a/http3/interfaces.py
+++ b/http3/interfaces.py
@@ -207,3 +207,21 @@ class ConcurrencyBackend:
                 yield self.run(async_iterator.__anext__)
             except StopAsyncIteration:
                 break
+
+    def background_manager(
+        self, coroutine: typing.Callable, args: typing.Any
+    ) -> "BaseBackgroundManager":
+        raise NotImplementedError()  # pragma: no cover
+
+
+class BaseBackgroundManager:
+    async def __aenter__(self) -> "BaseBackgroundManager":
+        raise NotImplementedError()  # pragma: no cover
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        raise NotImplementedError()  # pragma: no cover

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -147,6 +147,6 @@ def test_delete(server):
 def test_base_url(server):
     base_url = "http://127.0.0.1:8000/"
     with http3.Client(base_url=base_url) as http:
-        response = http.get('/')
+        response = http.get("/")
     assert response.status_code == 200
     assert str(response.url) == base_url

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 import typing
 
@@ -45,6 +46,7 @@ class MockHTTP2Server(BaseReader, BaseWriter):
     # BaseReader interface
 
     async def read(self, n, timeout) -> bytes:
+        await asyncio.sleep(0)
         send, self.buffer = self.buffer[:n], self.buffer[n:]
         return send
 


### PR DESCRIPTION
We're need to handle early connection closes properly.

* Client sends the initial part of the request.
* Server responds and closes the connection.
* Client attempts to keep sending the remainder of the request body, but the connection is closed.

We need to branch our flow control, so that sending the request body and reading the response are run in seperate flows of control.

Closes #95
Closes #96
