### PR TITLE
Read/Write timeout modes

### DIFF
--- a/http3/dispatch/http2.py
+++ b/http3/dispatch/http2.py
@@ -4,6 +4,7 @@ import typing
 import h2.connection
 import h2.events
 
+from ..concurrency import TimeoutFlag
 from ..config import DEFAULT_TIMEOUT_CONFIG, TimeoutConfig, TimeoutTypes
 from ..exceptions import ConnectTimeout, ReadTimeout
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
@@ -26,6 +27,7 @@ class HTTP2Connection:
         self.on_release = on_release
         self.h2_state = h2.connection.H2Connection()
         self.events = {}  # type: typing.Dict[int, typing.List[h2.events.Event]]
+        self.read_timeouts = {}  # type: typing.Dict[int, TimeoutFlag]
         self.initialized = False
 
     async def send(
@@ -39,6 +41,7 @@ class HTTP2Connection:
 
         stream_id = await self.send_headers(request, timeout)
         self.events[stream_id] = []
+        self.read_timeouts[stream_id] = TimeoutFlag()
 
         task, args = self.send_request_data, [stream_id, request.stream(), timeout]
         async with self.backend.background_manager(task, args=args):
@@ -85,9 +88,13 @@ class HTTP2Connection:
         stream: typing.AsyncIterator[bytes],
         timeout: TimeoutConfig = None,
     ) -> None:
-        async for data in stream:
-            await self.send_data(stream_id, data, timeout)
-        await self.end_stream(stream_id, timeout)
+        try:
+            async for data in stream:
+                await self.send_data(stream_id, data, timeout)
+            await self.end_stream(stream_id, timeout)
+        finally:
+            # Once we've sent the request we should enable read timeouts.
+            self.read_timeouts[stream_id].enable()
 
     async def send_data(
         self, stream_id: int, data: bytes, timeout: TimeoutConfig = None
@@ -113,6 +120,9 @@ class HTTP2Connection:
         """
         while True:
             event = await self.receive_event(stream_id, timeout)
+            # As soon as we start seeing response events, we should enable
+            # read timeouts, if we haven't already.
+            self.read_timeouts[stream_id].enable()
             if isinstance(event, h2.events.ResponseReceived):
                 break
 
@@ -140,7 +150,8 @@ class HTTP2Connection:
         self, stream_id: int, timeout: TimeoutConfig = None
     ) -> h2.events.Event:
         while not self.events[stream_id]:
-            data = await self.reader.read(self.READ_NUM_BYTES, timeout)
+            flag = self.read_timeouts[stream_id]
+            data = await self.reader.read(self.READ_NUM_BYTES, timeout, flag=flag)
             events = self.h2_state.receive_data(data)
             for event in events:
                 if getattr(event, "stream_id", 0):
@@ -153,6 +164,7 @@ class HTTP2Connection:
 
     async def response_closed(self, stream_id: int) -> None:
         del self.events[stream_id]
+        del self.read_timeouts[stream_id]
 
         if not self.events and self.on_release is not None:
             await self.on_release()

--- a/http3/interfaces.py
+++ b/http3/interfaces.py
@@ -127,7 +127,9 @@ class BaseReader:
     backend, or for stand-alone test cases.
     """
 
-    async def read(self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None) -> bytes:
+    async def read(
+        self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None
+    ) -> bytes:
         raise NotImplementedError()  # pragma: no cover
 
 

--- a/http3/interfaces.py
+++ b/http3/interfaces.py
@@ -127,7 +127,7 @@ class BaseReader:
     backend, or for stand-alone test cases.
     """
 
-    async def read(self, n: int, timeout: TimeoutConfig = None) -> bytes:
+    async def read(self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None) -> bytes:
         raise NotImplementedError()  # pragma: no cover
 
 

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -45,7 +45,7 @@ class MockHTTP2Server(BaseReader, BaseWriter):
 
     # BaseReader interface
 
-    async def read(self, n, timeout) -> bytes:
+    async def read(self, n, timeout, flag=None) -> bytes:
         await asyncio.sleep(0)
         send, self.buffer = self.buffer[:n], self.buffer[n:]
         return send


### PR DESCRIPTION
We need to ensure that we're only ever in *either* read-timeout or write-timeout mode.

During a request/response cycle we start in write-timeout mode.
We switch to read-timeout mode once we've sent the request, or once we start seeing an early response.
