### PR TITLE
Support client cert passwords, new TLS options

### DIFF
--- a/http3/config.py
+++ b/http3/config.py
@@ -123,8 +123,6 @@ class SSLConfig:
             context.load_verify_locations(cafile=ca_bundle_path)
         elif os.path.isdir(ca_bundle_path):
             context.load_verify_locations(capath=ca_bundle_path)
-        else:
-            context.load_default_certs(purpose=ssl.Purpose.SERVER_AUTH)
 
         if self.cert is not None:
             if isinstance(self.cert, str):

--- a/http3/config.py
+++ b/http3/config.py
@@ -117,8 +117,10 @@ class SSLConfig:
 
         # Disable using 'commonName' for SSLContext.check_hostname
         # when the 'subjectAltName' extension isn't available.
-        if hasattr(context, "hostname_checks_common_name"):
+        try:
             context.hostname_checks_common_name = False
+        except AttributeError:
+            pass
 
         if os.path.isfile(ca_bundle_path):
             context.load_verify_locations(cafile=ca_bundle_path)

--- a/http3/config.py
+++ b/http3/config.py
@@ -39,8 +39,6 @@ class SSLConfig:
     SSL Configuration.
     """
 
-    __slots__ = ("cert", "verify", "ssl_context")
-
     def __init__(self, *, cert: CertTypes = None, verify: VerifyTypes = True):
         self.cert = cert
         self.verify = verify
@@ -106,7 +104,6 @@ class SSLConfig:
         context = self._create_default_ssl_context()
         context.verify_mode = ssl.CERT_REQUIRED
         context.check_hostname = True
-        context.load_default_certs(purpose=ssl.Purpose.SERVER_AUTH)
 
         # Signal to server support for PHA in TLS 1.3. Raises an
         # AttributeError if only read-only access is implemented.
@@ -126,6 +123,8 @@ class SSLConfig:
             context.load_verify_locations(cafile=ca_bundle_path)
         elif os.path.isdir(ca_bundle_path):
             context.load_verify_locations(capath=ca_bundle_path)
+        else:
+            context.load_default_certs(purpose=ssl.Purpose.SERVER_AUTH)
 
         if self.cert is not None:
             if isinstance(self.cert, str):
@@ -162,8 +161,6 @@ class TimeoutConfig:
     """
     Timeout values.
     """
-
-    __slots__ = ("connect_timeout", "read_timeout", "write_timeout")
 
     def __init__(
         self,
@@ -214,8 +211,6 @@ class PoolLimits:
     """
     Limits on the number of connections in a connection pool.
     """
-
-    __slots__ = ("soft_limit", "hard_limit", "pool_timeout")
 
     def __init__(
         self,

--- a/http3/config.py
+++ b/http3/config.py
@@ -108,9 +108,12 @@ class SSLConfig:
         context.check_hostname = True
         context.load_default_certs(purpose=ssl.Purpose.SERVER_AUTH)
 
-        # Signal to server support for PHA in TLS 1.3
-        if hasattr(context, "post_handshake_auth"):
+        # Signal to server support for PHA in TLS 1.3. Raises an
+        # AttributeError if only read-only access is implemented.
+        try:
             context.post_handshake_auth = True
+        except AttributeError:
+            pass
 
         # Disable using 'commonName' for SSLContext.check_hostname
         # when the 'subjectAltName' extension isn't available.

--- a/http3/config.py
+++ b/http3/config.py
@@ -7,7 +7,7 @@ import certifi
 
 from .__version__ import __version__
 
-CertTypes = typing.Union[str, typing.Tuple[str, str]]
+CertTypes = typing.Union[str, typing.Tuple[str, str], typing.Tuple[str, str, str]]
 VerifyTypes = typing.Union[str, bool]
 TimeoutTypes = typing.Union[float, typing.Tuple[float, float, float], "TimeoutConfig"]
 
@@ -39,9 +39,13 @@ class SSLConfig:
     SSL Configuration.
     """
 
+    __slots__ = ("cert", "verify", "ssl_context")
+
     def __init__(self, *, cert: CertTypes = None, verify: VerifyTypes = True):
         self.cert = cert
         self.verify = verify
+
+        self.ssl_context: typing.Optional[ssl.SSLContext] = None
 
     def __eq__(self, other: typing.Any) -> bool:
         return (
@@ -64,7 +68,7 @@ class SSLConfig:
         return SSLConfig(cert=cert, verify=verify)
 
     async def load_ssl_context(self) -> ssl.SSLContext:
-        if not hasattr(self, "ssl_context"):
+        if self.ssl_context is None:
             if not self.verify:
                 self.ssl_context = self.load_ssl_context_no_verify()
             else:
@@ -80,11 +84,9 @@ class SSLConfig:
         """
         Return an SSL context for unverified connections.
         """
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        context.options |= ssl.OP_NO_SSLv2
-        context.options |= ssl.OP_NO_SSLv3
-        context.options |= ssl.OP_NO_COMPRESSION
-        context.set_default_verify_paths()
+        context = self._create_default_ssl_context()
+        context.verify_mode = ssl.CERT_NONE
+        context.check_hostname = False
         return context
 
     def load_ssl_context_verify(self) -> ssl.SSLContext:
@@ -101,20 +103,19 @@ class SSLConfig:
                 "invalid path: {}".format(self.verify)
             )
 
-        context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
-
+        context = self._create_default_ssl_context()
         context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = True
+        context.load_default_certs(purpose=ssl.Purpose.SERVER_AUTH)
 
-        context.options |= ssl.OP_NO_SSLv2
-        context.options |= ssl.OP_NO_SSLv3
-        context.options |= ssl.OP_NO_COMPRESSION
+        # Signal to server support for PHA in TLS 1.3
+        if hasattr(context, "post_handshake_auth"):
+            context.post_handshake_auth = True
 
-        context.set_ciphers(DEFAULT_CIPHERS)
-
-        if ssl.HAS_ALPN:
-            context.set_alpn_protocols(["h2", "http/1.1"])
-        if ssl.HAS_NPN:
-            context.set_npn_protocols(["h2", "http/1.1"])
+        # Disable using 'commonName' for SSLContext.check_hostname
+        # when the 'subjectAltName' extension isn't available.
+        if hasattr(context, "hostname_checks_common_name"):
+            context.hostname_checks_common_name = False
 
         if os.path.isfile(ca_bundle_path):
             context.load_verify_locations(cafile=ca_bundle_path)
@@ -124,8 +125,30 @@ class SSLConfig:
         if self.cert is not None:
             if isinstance(self.cert, str):
                 context.load_cert_chain(certfile=self.cert)
-            else:
+            elif isinstance(self.cert, tuple) and len(self.cert) == 2:
                 context.load_cert_chain(certfile=self.cert[0], keyfile=self.cert[1])
+            else:
+                context.load_cert_chain(
+                    certfile=self.cert[0], keyfile=self.cert[1], password=self.cert[2]
+                )
+
+        return context
+
+    def _create_default_ssl_context(self) -> ssl.SSLContext:
+        """
+        Creates the default SSLContext object that's used for both verified
+        and unverified connections.
+        """
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.options |= ssl.OP_NO_SSLv2
+        context.options |= ssl.OP_NO_SSLv3
+        context.options |= ssl.OP_NO_COMPRESSION
+        context.set_ciphers(DEFAULT_CIPHERS)
+
+        if ssl.HAS_ALPN:
+            context.set_alpn_protocols(["h2", "http/1.1"])
+        if ssl.HAS_NPN:
+            context.set_npn_protocols(["h2", "http/1.1"])
 
         return context
 
@@ -134,6 +157,8 @@ class TimeoutConfig:
     """
     Timeout values.
     """
+
+    __slots__ = ("connect_timeout", "read_timeout", "write_timeout")
 
     def __init__(
         self,
@@ -175,7 +200,7 @@ class TimeoutConfig:
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        if len(set([self.connect_timeout, self.read_timeout, self.write_timeout])) == 1:
+        if len({self.connect_timeout, self.read_timeout, self.write_timeout}) == 1:
             return f"{class_name}(timeout={self.connect_timeout})"
         return f"{class_name}(connect_timeout={self.connect_timeout}, read_timeout={self.read_timeout}, write_timeout={self.write_timeout})"
 
@@ -184,6 +209,8 @@ class PoolLimits:
     """
     Limits on the number of connections in a connection pool.
     """
+
+    __slots__ = ("soft_limit", "hard_limit", "pool_timeout")
 
     def __init__(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ mkdocs-material
 # Testing
 autoflake
 black
+cryptography
 isort
 mypy
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,13 @@ import asyncio
 
 import pytest
 import trustme
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    Encoding,
+    PrivateFormat,
+)
 from uvicorn.config import Config
 from uvicorn.main import Server
-from cryptography.hazmat.primitives.serialization import (
-    PrivateFormat, BestAvailableEncryption
-)
-from cryptography.hazmat.primitives.serialization import Encoding
 
 
 async def app(scope, receive, send):
@@ -88,13 +89,14 @@ class CAWithPKEncryption(trustme.CA):
     """Implementation of trustme.CA() that emits private keys
     that are encrypted with a password.
     """
+
     @property
     def private_key_pem(self):
         return trustme.Blob(
             self._private_key.private_bytes(
                 Encoding.PEM,
                 PrivateFormat.TraditionalOpenSSL,
-                BestAvailableEncryption(password=b"password")
+                BestAvailableEncryption(password=b"password"),
             )
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,24 @@ async def test_load_ssl_config_cert_and_key(cert_and_key_paths):
 
 
 @pytest.mark.asyncio
+async def test_load_ssl_config_cert_and_key(cert_and_encrypted_key_paths):
+    cert_path, key_path = cert_and_encrypted_key_paths
+    ssl_config = http3.SSLConfig(cert=(cert_path, key_path, "password"))
+    context = await ssl_config.load_ssl_context()
+    assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+    assert context.check_hostname is True
+
+
+@pytest.mark.asyncio
+async def test_load_ssl_config_cert_and_key_invalid_password(cert_and_encrypted_key_paths):
+    cert_path, key_path = cert_and_encrypted_key_paths
+    ssl_config = http3.SSLConfig(cert=(cert_path, key_path, "password1"))
+
+    with pytest.raises(ssl.SSLError):
+        await ssl_config.load_ssl_context()
+
+
+@pytest.mark.asyncio
 async def test_load_ssl_config_cert_without_key_raises(cert_and_key_paths):
     cert_path, _ = cert_and_key_paths
     ssl_config = http3.SSLConfig(cert=cert_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ async def test_load_ssl_config():
     ssl_config = http3.SSLConfig()
     context = await ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+    assert context.check_hostname is True
 
 
 @pytest.mark.asyncio
@@ -25,6 +26,7 @@ async def test_load_ssl_config_verify_existing_file():
     ssl_config = http3.SSLConfig(verify=http3.config.DEFAULT_CA_BUNDLE_PATH)
     context = await ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+    assert context.check_hostname is True
 
 
 @pytest.mark.asyncio
@@ -33,6 +35,7 @@ async def test_load_ssl_config_verify_directory():
     ssl_config = http3.SSLConfig(verify=path)
     context = await ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+    assert context.check_hostname is True
 
 
 @pytest.mark.asyncio
@@ -41,6 +44,7 @@ async def test_load_ssl_config_cert_and_key(cert_and_key_paths):
     ssl_config = http3.SSLConfig(cert=(cert_path, key_path))
     context = await ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+    assert context.check_hostname is True
 
 
 @pytest.mark.asyncio
@@ -52,10 +56,11 @@ async def test_load_ssl_config_cert_without_key_raises(cert_and_key_paths):
 
 
 @pytest.mark.asyncio
-async def test_load_ssl_config_no_verify(verify=False):
+async def test_load_ssl_config_no_verify():
     ssl_config = http3.SSLConfig(verify=False)
     context = await ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_NONE
+    assert context.check_hostname is False
 
 
 def test_ssl_repr():
@@ -102,5 +107,5 @@ def test_timeout_from_tuple():
 
 
 def test_timeout_from_config_instance():
-    timeout = http3.TimeoutConfig(timeout=(5.0))
+    timeout = http3.TimeoutConfig(timeout=5.0)
     assert http3.TimeoutConfig(timeout) == http3.TimeoutConfig(timeout=5.0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,7 @@ async def test_load_ssl_config_cert_and_key(cert_and_key_paths):
 
 
 @pytest.mark.asyncio
-async def test_load_ssl_config_cert_and_key(cert_and_encrypted_key_paths):
+async def test_load_ssl_config_cert_and_encrypted_key(cert_and_encrypted_key_paths):
     cert_path, key_path = cert_and_encrypted_key_paths
     ssl_config = http3.SSLConfig(cert=(cert_path, key_path, "password"))
     context = await ssl_config.load_ssl_context()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,7 +57,9 @@ async def test_load_ssl_config_cert_and_key(cert_and_encrypted_key_paths):
 
 
 @pytest.mark.asyncio
-async def test_load_ssl_config_cert_and_key_invalid_password(cert_and_encrypted_key_paths):
+async def test_load_ssl_config_cert_and_key_invalid_password(
+    cert_and_encrypted_key_paths
+):
     cert_path, key_path = cert_and_encrypted_key_paths
     ssl_config = http3.SSLConfig(cert=(cert_path, key_path, "password1"))
 


### PR DESCRIPTION
Regarding disabling commonName: commonName support has been deprecated in urllib3 for over 5 years now and Chrome and Firefox don't support commonName for new certificates I think it's time we turn it off where we can (Python 3.7+ and OpenSSL 1.1.0+).
